### PR TITLE
MenuItem: allow data to be structured

### DIFF
--- a/src/DI/MenuExtension.php
+++ b/src/DI/MenuExtension.php
@@ -43,7 +43,7 @@ final class MenuExtension extends CompilerExtension
 			'action' => Expect::type('string|array'),
 			'link' => Expect::string(),
 			'include' => Expect::type('string|array'),
-			'data' => Expect::arrayOf('string', 'string'),
+			'data' => Expect::arrayOf('mixed', 'string'),
 			'items' => Expect::array(),
 			'visibility' => Expect::from(new MenuVisibility()),
 		]);

--- a/src/IMenuItem.php
+++ b/src/IMenuItem.php
@@ -32,20 +32,20 @@ interface IMenuItem extends IMenuItemsContainer
 	public function getRealAbsoluteLink(): string;
 
 	/**
-	 * @return array<string, string>
+	 * @return array<string, mixed>
 	 */
 	public function getData(): array;
 
 	/**
-	 * @param array<string, string> $data
+	 * @param array<string, mixed> $data
 	 */
 	public function setData(array $data): void;
 
 	public function hasDataItem(string $name): bool;
 
-	public function getDataItem(string $name, ?string $default = null): ?string;
+	public function getDataItem(string $name, mixed $default = null): mixed;
 
-	public function addDataItem(string $name, string $value): void;
+	public function addDataItem(string $name, mixed $value): void;
 
 	/**
 	 * @param string[] $include

--- a/src/Traits/MenuItemData.php
+++ b/src/Traits/MenuItemData.php
@@ -29,7 +29,7 @@ trait MenuItemData
 		return array_key_exists($name, $this->data);
 	}
 
-	public function getDataItem(string $name, ?string $default = null): ?string
+	public function getDataItem(string $name, mixed $default = null): mixed
 	{
 		if (!array_key_exists($name, $this->data)) {
 			return $default;
@@ -38,7 +38,7 @@ trait MenuItemData
 		return $this->data[$name];
 	}
 
-	public function addDataItem(string $name, string $value): void
+	public function addDataItem(string $name, mixed $value): void
 	{
 		$this->data[$name] = $value;
 	}

--- a/tests/cases/DI/MenuExtensionTest.php
+++ b/tests/cases/DI/MenuExtensionTest.php
@@ -32,6 +32,21 @@ final class MenuExtensionTest extends AbstractTestCase
 		Assert::type(MenuComponent::class, $dic->getService('menu.component.factory')->create('default'));
 	}
 
+	public function testDataItems(): void
+	{
+		$dic = $this->createContainer();
+
+		$container = $dic->getService('menu.container');
+		/** @var \Contributte\MenuControl\IMenu $menu */
+		$menu = $container->getMenu('default');
+
+		$item = $menu->getItem('Homepage');
+
+		Assert::type('bool', $item->getDataItem('bool'));
+		Assert::type('string', $item->getDataItem('icon'));
+		Assert::type('array', $item->getDataItem('structured'));
+	}
+
 	public function testRender(): void
 	{
 		$dic = $this->createContainer();

--- a/tests/cases/DI/config.neon
+++ b/tests/cases/DI/config.neon
@@ -22,3 +22,8 @@ menu:
 				items:
 					Category:
 						action: Category:default
+				data:
+					icon: fa fa-home
+					bool: true
+					structured:
+						key: value


### PR DESCRIPTION
Docs example states that you can have structured data attached to MenuItem: https://github.com/contributte/menu-control/tree/master/.docs#custom-data

Allowing only strings is too restrictive and mostly unusable.