### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Replace `phpdbg` with plain `php` in the `coverage` Makefile target so this repository matches the org-wide coverage migration tracked in contributte/contributte#73.

## Motivation

`phpdbg` is being removed from Contributte coverage targets. This keeps `menu-control` aligned with the new convention and avoids depending on the PHPDBG SAPI.

## Changes

- switch the GitHub Actions coverage command from `-p phpdbg` to `-p php`
- switch the local coverage command from `-p phpdbg` to `-p php`

## Testing

- [ ] Tests pass locally
- [ ] CI passes
- [ ] Manual verification (if applicable)
- `make coverage` currently fails in this environment because PHP CLI has neither Xdebug nor PCOV installed: `Code coverage functionality requires Xdebug or PCOV extension or PHPDBG SAPI (used php)`