### PR TITLE
Composer: require PHP >=8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "issues": "https://github.com/contributte/menu-control/issues"
   },
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "nette/di": "^3.1.1",
     "nette/utils": "^4.0",
     "nette/application": "^3.1.10",


### PR DESCRIPTION
Updates the PHP requirement in composer.json from >=8.1 to >=8.2.